### PR TITLE
fix: support releasing k8s resources

### DIFF
--- a/packs/javascript/charts/resources/README.md
+++ b/packs/javascript/charts/resources/README.md
@@ -1,0 +1,9 @@
+## Kubernetes Resources
+
+This directory is where released kubernetes resources will be generated in each version (a git tag).
+
+You can then consume the resources via tools like:
+
+* [kubectl](https://kubernetes.io/docs/reference/kubectl/kubectl/)
+* [kustomize](https://kustomize.io/)
+* [kpt](https://googlecontainertools.github.io/kpt/)

--- a/packs/javascript/pipeline.yaml
+++ b/packs/javascript/pipeline.yaml
@@ -46,7 +46,7 @@ pipelines:
         name: next-version
         image: gcr.io/jenkinsxio-labs-private/jxl
         comment: so we can retrieve the version in later steps
-      - sh: "mkdir -p kubernetes; helm template --output-dir=kubernetes $REPO_NAME charts/$REPO_NAME; git add *; git commit -m 'fix: generated helm template'"
+      - sh: "mkdir -p kubernetes; cd kubernetes; helm template --output-dir=. $REPO_NAME ../charts/$REPO_NAME; git add *; git commit -m 'fix: generated helm template'"
         name: next-version
         image: gcr.io/jenkinsxio-labs-private/jxl
         comment: so we can retrieve the version in later steps

--- a/packs/javascript/pipeline.yaml
+++ b/packs/javascript/pipeline.yaml
@@ -40,3 +40,16 @@ pipelines:
           sh: jx promote -b --all-auto --timeout 1h --version \$(cat ../../VERSION)
           name: jx-promote
           image: gcr.io/jenkinsxio-labs-private/jxl
+    setVersion:
+      steps:
+      - sh: jx step next-version --filename package.json
+        name: next-version
+        image: gcr.io/jenkinsxio-labs-private/jxl
+        comment: so we can retrieve the version in later steps
+      - sh: "mkdir -p kubernetes; cd kubernetes; helm template --output-dir=. $REPO_NAME ../charts/$REPO_NAME; git add *; git commit -m 'fix: generated helm template'"
+        name: next-version
+        image: gcr.io/jenkinsxio-labs-private/jxl
+        comment: so we can retrieve the version in later steps
+      - sh: jx step tag --version \$(cat VERSION)
+        image: gcr.io/jenkinsxio-labs-private/jxl
+        name: tag-version

--- a/packs/javascript/pipeline.yaml
+++ b/packs/javascript/pipeline.yaml
@@ -53,6 +53,9 @@ pipelines:
         name: helm-template
         image: gcr.io/jenkinsxio-labs-private/jxl
         comment: lets release the versioned kubernetes resources for consumption via kubectl/kpt/kustomize
+      - sh: "git add charts/* && git commit -m 'fix: generate kubernetes resources"
+        image: gcr.io/jenkinsxio-labs-private/jxl
+        name: git-commit-helm
       - sh: jx step tag --version \$(cat VERSION)
         image: gcr.io/jenkinsxio-labs-private/jxl
         name: tag-version

--- a/packs/javascript/pipeline.yaml
+++ b/packs/javascript/pipeline.yaml
@@ -53,7 +53,8 @@ pipelines:
         name: helm-template
         image: gcr.io/jenkinsxio-labs-private/jxl
         comment: lets release the versioned kubernetes resources for consumption via kubectl/kpt/kustomize
-      - sh: "git add charts/* && git commit -m 'fix: generate kubernetes resources"
+      - sh: |-
+          git add charts/* && git commit -m "fix: generate kubernetes resources"
         image: gcr.io/jenkinsxio-labs-private/jxl
         name: git-commit-helm
       - sh: jx step tag --version \$(cat VERSION)

--- a/packs/javascript/pipeline.yaml
+++ b/packs/javascript/pipeline.yaml
@@ -53,10 +53,6 @@ pipelines:
         name: helm-template
         image: gcr.io/jenkinsxio-labs-private/jxl
         comment: lets release the versioned kubernetes resources for consumption via kubectl/kpt/kustomize
-      - sh: |-
-          git add charts/* && git commit -m "fix: generate kubernetes resources"
-        image: gcr.io/jenkinsxio-labs-private/jxl
-        name: git-commit-helm
       - sh: jx step tag --version \$(cat VERSION)
         image: gcr.io/jenkinsxio-labs-private/jxl
         name: tag-version

--- a/packs/javascript/pipeline.yaml
+++ b/packs/javascript/pipeline.yaml
@@ -46,7 +46,7 @@ pipelines:
         name: next-version
         image: gcr.io/jenkinsxio-labs-private/jxl
         comment: so we can retrieve the version in later steps
-      - sh: "mkdir -p kubernetes; cd kubernetes; helm template --output-dir=. $REPO_NAME ../charts/$REPO_NAME; git add *; git commit -m 'fix: generated helm template'"
+      - sh: "mkdir -p kubernetes; helm template --output-dir=kubernetes $REPO_NAME charts/$REPO_NAME; git add *; git commit -m 'fix: generated helm template'"
         name: next-version
         image: gcr.io/jenkinsxio-labs-private/jxl
         comment: so we can retrieve the version in later steps

--- a/packs/javascript/pipeline.yaml
+++ b/packs/javascript/pipeline.yaml
@@ -46,10 +46,13 @@ pipelines:
         name: next-version
         image: gcr.io/jenkinsxio-labs-private/jxl
         comment: so we can retrieve the version in later steps
-      - sh: "mkdir -p kubernetes; helm template --output-dir=kubernetes $REPO_NAME charts/$REPO_NAME; git add *; git commit -m 'fix: generated helm template'"
-        name: next-version
+      - sh: jx step tag --version \$(cat VERSION) --no-apply
         image: gcr.io/jenkinsxio-labs-private/jxl
-        comment: so we can retrieve the version in later steps
+        name: update-version
+      - sh: "jxl step helm template"
+        name: helm-template
+        image: gcr.io/jenkinsxio-labs-private/jxl
+        comment: lets release the versioned kubernetes resources for consumption via kubectl/kpt/kustomize
       - sh: jx step tag --version \$(cat VERSION)
         image: gcr.io/jenkinsxio-labs-private/jxl
         name: tag-version


### PR DESCRIPTION
so that when we release a quickstart we can consume the k8s resources directly without helm (if folks want to)