### PR TITLE
fix: Add ingress defaults

### DIFF
--- a/packs/python/charts/values.yaml
+++ b/packs/python/charts/values.yaml
@@ -68,3 +68,23 @@ readinessProbe:
   periodSeconds: 10
   successThreshold: 1
   timeoutSeconds: 1
+
+# values we use from the `jx-requirements.yml` file if we are using helmfile and helm 3
+jxRequirements:
+  ingress:
+    domain: ""
+    externalDNS: false
+    namespaceSubDomain: -jx.
+    serviceType: ""
+    tls:
+      email: ""
+      enabled: false
+      production: false
+      secretName: ""
+
+    # For Kubernetes v1.14+, use 'networking.k8s.io/v1beta1'
+    apiVersion: "extensions/v1beta1"
+
+    # shared ingress annotations on all services
+    annotations:
+    #  kubernetes.io/ingress.class: nginx


### PR DESCRIPTION
Adds ingress defaults the same way as in the go pack https://github.com/jenkins-x/jxr-packs-kubernetes/blob/master/packs/go/charts/values.yaml#L76 . This allows to build python quickstart without any modifications