### PR TITLE
fix: prevent duplicated setVersion steps

### DIFF
--- a/packs/javascript/pipeline.yaml
+++ b/packs/javascript/pipeline.yaml
@@ -51,6 +51,7 @@ pipelines:
           name: jx-promote
           image: gcr.io/jenkinsxio/jx-cli
     setVersion:
+      replace: true
       steps:
       - sh: jx step next-version --filename package.json
         name: next-version


### PR DESCRIPTION
It seems that without `replace: true` on setVersion stage the `next-version` and `tag-version` steps are added to the same named steps from the classic javascript buildpack (https://github.com/jenkins-x-labs/jenkins-x-classic/blob/master/packs/javascript/pipeline.yaml#L17 which is being extended here) and in result duplicated, which finally results in an unnecessary fix version added in releases.

